### PR TITLE
Encapsulate errors in Errors module.

### DIFF
--- a/lib/openapi_parameters/errors.rb
+++ b/lib/openapi_parameters/errors.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module OpenapiParameters
-  class Error < StandardError
-  end
+  module Errors
+    class Error < StandardError
+    end
 
-  class NotSupportedError < Error
+    class NotSupportedError < Error
+    end
   end
 end

--- a/lib/openapi_parameters/parameter.rb
+++ b/lib/openapi_parameters/parameter.rb
@@ -93,7 +93,7 @@ module OpenapiParameters
     def check_supported!(definition)
       return unless definition.values.any? { |v| v.is_a?(Hash) && v.key?(REF) }
 
-      raise NotSupportedError,
+      raise OpenapiParameters::Errors::NotSupportedError,
             "Parameter schema with $ref is not supported: #{definition.inspect}"
     end
   end

--- a/spec/openapi_parameters/parameter_spec.rb
+++ b/spec/openapi_parameters/parameter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OpenapiParameters::Parameter do
         }
       }
       expect { described_class.new(definition) }.to raise_error(
-        OpenapiParameters::NotSupportedError
+        OpenapiParameters::Errors::NotSupportedError
       )
     end
   end


### PR DESCRIPTION
Hi,
I ran into [the issue with zeitwerk described here](https://github.com/ahx/openapi_parameters/issues/1]. Zeitwerk expects the class name (or the module name) to match the classified file name to be defined in the file. That's not the case for the `lib/openapi_parameters/errors.rb` and leads to the aforementioned issue.

Encapsulating all errors in `module Errors` seems to do the trick. Please let me know what you think about it! :)

I opened it to v0.2.2 because the newest `openapi_first` (`1.0.0.beta4`) does not allow v0.3.0 as a dependency.