### PR TITLE
Raise `Rack::Utils::InvalidParameterError` when query paramter has invalid encoding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Raise `Rack::Utils::InvalidParameterError` when query paramter has invalid "%"-encoding
+
 ## [0.5.0] - 2025-04-01
 
 - Add option to remove "[]" from unpacked query openapi_parameters

--- a/lib/openapi_parameters/error.rb
+++ b/lib/openapi_parameters/error.rb
@@ -6,4 +6,6 @@ module OpenapiParameters
 
   class NotSupportetError < Error
   end
+
+  InvalidParameterError = Rack::Utils::InvalidParameterError
 end

--- a/lib/openapi_parameters/query.rb
+++ b/lib/openapi_parameters/query.rb
@@ -14,7 +14,7 @@ module OpenapiParameters
     end
 
     def unpack(query_string) # rubocop:disable Metrics/AbcSize
-      parsed_query = Rack::Utils.parse_query(query_string)
+      parsed_query = parse_query(query_string)
       parameters.each_with_object({}) do |parameter, result|
         if parameter.deep_object?
           parsed_nested_query = Rack::Utils.parse_nested_query(query_string)
@@ -39,6 +39,14 @@ module OpenapiParameters
     private attr_reader :remove_array_brackets
 
     private
+
+    def parse_query(query_string)
+      Rack::Utils.parse_query(query_string) do |s|
+        Rack::Utils.unescape(s)
+      rescue ArgumentError => e
+        raise Rack::Utils::InvalidParameterError, e.message
+      end
+    end
 
     def convert_primitive(value, parameter)
       return value unless @convert

--- a/spec/openapi_parameters/query_spec.rb
+++ b/spec/openapi_parameters/query_spec.rb
@@ -15,5 +15,19 @@ RSpec.describe OpenapiParameters::Query do
         expect(value).to eq(unpacked_value)
       end
     end
+
+    context 'with invalid query string encoding' do
+      it 'raises an exception' do
+        parameter = { 'in' => 'query', 'name' => 'limit' }
+        query_string = 'limit=%E0%A4%A'
+        unpacker = described_class.new([parameter])
+        expect do
+          unpacker.unpack(query_string)
+        end.to raise_error(OpenapiParameters::InvalidParameterError, 'invalid %-encoding (%E0%A4%A)')
+        expect do
+          unpacker.unpack(query_string)
+        end.to raise_error(Rack::Utils::InvalidParameterError, 'invalid %-encoding (%E0%A4%A)')
+      end
+    end
   end
 end


### PR DESCRIPTION
Related to https://github.com/ahx/openapi_first/issues/372