### PR TITLE
No deep nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- No longer parse more than one level of nested objects when parsing `deepObject` parameters. This is actually in line with what `deepObject` supports.
+
 ## [0.7.0] - 2025-09-12
 
 - Correctly handle `style:deepObject` with `explode: true` and parse into array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.8.0] - 2025-09-17
+
 - No longer parse more than one level of nested objects when parsing `deepObject` parameters. This is actually in line with what `deepObject` supports.
 
 ## [0.7.0] - 2025-09-12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       racc
     prism (1.4.0)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.1)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_parameters (0.7.0)
+    openapi_parameters (0.8.0)
       rack (>= 2.2)
 
 GEM

--- a/lib/openapi_parameters/version.rb
+++ b/lib/openapi_parameters/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiParameters
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/spec/openapi_parameters/query-parameter-tests.yaml
+++ b/spec/openapi_parameters/query-parameter-tests.yaml
@@ -68,7 +68,7 @@
   unpacked_value:
     id: abc
 
-- description: Does not add key if not set
+- description: Does not add key if query string is empty
   parameter:
     in: query
     name: id
@@ -330,11 +330,6 @@
           type: integer
         B:
           type: integer
-        nested:
-          type: object
-          properties:
-            a:
-              type: integer
   query_string: color[R]=100&color[G]=200&color[B]=150
   unpacked_value:
     color:
@@ -342,7 +337,7 @@
       G: 200
       B: 150
 
-- description: Returns the original value if unpacking fails
+- description: Returns an empty object if unpacking fails
   parameter:
     in: query
     name: color
@@ -353,18 +348,8 @@
       properties:
         R:
           type: integer
-        G:
-          type: integer
-        B:
-          type: integer
-        nested:
-          type: object
-          properties:
-            a:
-              type: integer
   query_string: color=RGB
-  unpacked_value:
-    color: RGB
+  unpacked_value: {}
 
 - description: Does not add key if not set
   parameter:
@@ -389,11 +374,10 @@
   query_string: ""
   unpacked_value: {}
 
-- description: Supports nested objects
+- description: Ignores nested objects
   parameter:
     in: query
     name: color
-    explode: true
     style: deepObject
     schema:
       type: object
@@ -413,14 +397,11 @@
   unpacked_value:
     color:
       R: 100
-      nested:
-        a: 42
 
 - description: Still returns an object without object type specified
   parameter:
     in: query
     name: color
-    explode: true
     style: deepObject
     schema:
       properties:
@@ -449,7 +430,7 @@
     color:
       values: [100]
 
-- description: Converts exploded multiple values
+- description: Converts multiple values in nested array
   parameter:
     in: query
     name: color
@@ -467,7 +448,49 @@
     color:
       values: [100, 255]
 
-- description: Does not convert non-exploded nested arrays
+- description: Does does not add rack-style parameters unless described
+  parameter:
+    in: query
+    name: color
+    explode: true
+    style: deepObject
+    schema:
+      type: object
+      properties:
+        values:
+          type: array
+          items:
+            type: integer
+  query_string: color[values][]=100&color[values][]=255
+  unpacked_value: {}
+
+- description: Unpacks rack-style array values if they are described alongside other deepObjects
+  parameter:
+    - in: query
+      name: filter
+      explode: true
+      style: deepObject
+      schema:
+        type: object
+        properties:
+          id:
+            type: array
+            items:
+              type: integer
+    - in: query
+      name: color[values][]
+      explode: true
+      schema:
+        type: array
+        items:
+          type: integer
+  query_string: color[values][]=100&color[values][]=255&filter[id]=200
+  unpacked_value:
+    filter:
+      id: [200]
+    'color[values][]': [100, 255]
+
+- description: Converts non-exploded nested arrays
   parameter:
     in: query
     name: color
@@ -482,7 +505,7 @@
   query_string: color[values]=100&color[values]=255
   unpacked_value:
     color:
-      values: "255"
+      values: [255]
 
 - description: Does not convert comma-separated values
   parameter:

--- a/spec/openapi_parameters/query_spec.rb
+++ b/spec/openapi_parameters/query_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe OpenapiParameters::Query do
                                                                              'query_string', 'unpacked_value')
       it description do
         options = test['options'].to_h.transform_keys!(&:to_sym)
-        value = described_class.new([parameter], **options).unpack(query_string)
+        parameter = [parameter] unless parameter.is_a?(Array)
+        value = described_class.new(parameter, **options).unpack(query_string)
         expect(value).to eq(unpacked_value)
       end
     end


### PR DESCRIPTION
- No longer parse more than one level of nested objects when parsing `deepObject` parameters. This is actually in line with what `deepObject` supports.